### PR TITLE
Fix build info to facilitate pip installing directly from git.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+0.1.13 (14-May 18)
+
+- Make embedding users more efficient
+
 0.1.10 (8-Jan-18)
 
 - fix for update item

--- a/pytimecamp.egg-info/PKG-INFO
+++ b/pytimecamp.egg-info/PKG-INFO
@@ -1,163 +1,315 @@
 Metadata-Version: 1.1
 Name: pytimecamp
-Version: 0.1.3
+Version: 0.1.13
 Summary: A wrapper around the Timecamp API.
 Home-page: https://pythonhosted.org/pytimecamp/
 Author: Steven Rossiter
 Author-email: steve@agiletek.co.uk
 License: MIT
-Description: PyTimeCamp
-        ==========
-        
-        A python interface to the `TimeCamp
-        API <https://github.com/timecamp2/timecamp-api>`__.
-        
-        Currently supports interface to:
-        
-        -  Users
-        -  Tasks
-        -  Entries
-        -  Activities
-        
-        External dependencies
-        ---------------------
-        
-        Only tested on Python3.4 at present
-        
-        `requests <http://docs.python-requests.org/en/latest/>`__ (like almost
-        any python library involving http)
-        
-        `dateutil <https://dateutil.readthedocs.org/en/latest/>`__ (to deal with
-        filtering by dates)
-        
-        Installing
-        ----------
-        
-        ``python setup.py install``
-        
-        API Summary
-        -----------
-        
-        TimeCamp:
-        
-        -  users
-        -  user\_by\_id(id)
-        -  user\_by\_name(name)
-        -  tasks(embed\_users=False) - embedded users on lots of tasks is
-           currently very expensive due to lack of caching
-        -  task\_by\_id(task\_id, embed\_users=False)
-        -  add\_task(task\_data)
-        -  update\_task(task\_data)
-        -  entries(from\_date=None, to\_date=None, task\_ids=None,
-           user\_ids=None, embed\_user=False,with\_subtasks=False) - no
-           "to\_date" or "from\_date" dates assumes all time to now
-        -  add\_entry(entry\_data)
-        -  update\_entry(entry\_data)
-        -  activities\_by\_day(date=TODAY, user\_id=None)
-        -  applications(application\_ids=None)
-        -  window\_titles(window\_title\_ids=None)
-        
-        Methods return TCItem object (or lists or generators) where the top
-        level keys are mapped to object attributes.
-        
-        Example Usage
-        -------------
-        
-        ::
-        
-            from pytimecamp import Timecamp
-        
-            tc = Timecamp("s0met0k3nap1k3ystr1ng")
-            for u in tc.users:
-                print(u)
-                # <User 444444>
-                # login_time: 2015-06-01 08:27:14
-                # email: nospamthanks@agiletek.co.mk
-                # display_name: Steven Rossiter
-                # user_id: 444444
-                # synch_time: 2015-06-04 15:08:37
-                # login_count: 98
-        
-        
-            # Get my entries since 23rd May
-            me = list(tc.users)[0] # Timecamp.users is a generator
-        
-            # You pass dates as strings written like a normal person! (almost any date format 
-            # will work - dateutil rocks - but try not confuse it with DDMMYY vs. MMDDYY)
-            for entry in tc.entries(from_date="23rd May 2015", user_ids=[me.user_id]):
-                print(entry)
-                # <Entry 44444444>
-                # duration: 1374
-                # user_name: Steven Rossiter
-                # locked: 0
-                # start_time: 10:09:13
-                # billable: 0
-                # description:
-                # name: CRM, Sales & Marketing
-                # id: 44444444
-                # last_modify: 2015-05-26 11:38:24
-                # end_time: 10:32:11
-                # user_id: 444444
-                # task_id: 4444444
-                # invoiceId: 0
-                # date: 2015-05-26
-        
-            # get the task with ID 4444444 with the users embedded
-            task = tc.task_by_id(4444444,True)
-            print(task)
-            # <Task 4444444>
-            # tags: CRM, Sales, Marketing, INT002
-            # user_access_type: 3
-            # archived: 0
-            # users: [
-            # <User 444445>
-            # display_name: Hugh Martindale
-            # email: nospamthanks@agiletek.co.mk
-            # synch_time: 2015-06-03 21:04:14
-            # login_time: 2015-06-02 14:23:02
-            # user_id: 49192
-            # login_count: 26,
-            # <User 444444>
-            # display_name: Steven Rossiter
-            # email: nospamthanks@agiletek.co.mk
-            # synch_time: 2015-06-04 15:13:42
-            # login_time: 2015-06-01 08:27:14
-            # user_id: 49191
-            # login_count: 98,
-            # <User 444446>
-            # display_name: Truan Willis
-            # email: nospamthanks@agiletek.co.mk
-            # synch_time: 2015-06-04 15:17:58
-            # login_time: 2015-06-03 11:32:22
-            # user_id: 444446
-            # login_count: 81,
-            # <User 444447>
-            # display_name: Richard Langdon
-            # email: richard@agiletek.co.uk
-            # synch_time: 2015-06-04 15:14:36
-            # login_time: 2015-06-03 20:01:52
-            # user_id: 444447
-            # login_count: 103]
-            # external_parent_id: None
-            # name: CRM, Sales & Marketing
-            # billable: 0
-            # parent_id: 3333333
-            # task_id: 4444444
-            # perms: {'5': 3, '6': 3, '7': 3, '1': 3, '3': 3, '2': 3}
-            # color: #34C644
-            # root_group_id: 27055
-            # level: 2
-            # budgeted: 0
-        
-        Licence
-        -------
-        
-        MIT (c) 2015 AgileTek Engineering Limited
-        
-        Changelog
-        ---------
-        
-        v0.
+Description: PyTimeCamp
+
+        ==========
+
+        
+
+        A python interface to the `TimeCamp
+
+        API <https://github.com/timecamp2/timecamp-api>`__.
+
+        
+
+        Currently supports interface to:
+
+        
+
+        -  Users
+
+        -  Tasks
+
+        -  Entries
+
+        -  Activities
+
+        
+
+        External dependencies
+
+        ---------------------
+
+        
+
+        Only tested on Python3.4 at present
+
+        
+
+        `requests <http://docs.python-requests.org/en/latest/>`__ (like almost
+
+        any python library involving http)
+
+        
+
+        `dateutil <https://dateutil.readthedocs.org/en/latest/>`__ (to deal with
+
+        filtering by dates)
+
+        
+
+        Installing
+
+        ----------
+
+        
+
+        ``python setup.py install``
+
+        
+
+        API Summary
+
+        -----------
+
+        
+
+        TimeCamp:
+
+        
+
+        -  users
+
+        -  user\_by\_id(id)
+
+        -  user\_by\_name(name)
+
+        -  tasks(embed\_users=False) - embedded users on lots of tasks is
+
+           currently very expensive due to lack of caching
+
+        -  task\_by\_id(task\_id, embed\_users=False)
+
+        -  add\_task(task\_data)
+
+        -  update\_task(task\_data)
+
+        -  entries(from\_date=None, to\_date=None, task\_ids=None,
+
+           user\_ids=None, embed\_user=False,with\_subtasks=False) - no
+
+           "to\_date" or "from\_date" dates assumes all time to now
+
+        -  add\_entry(entry\_data)
+
+        -  update\_entry(entry\_data)
+
+        -  activities\_by\_day(date=TODAY, user\_id=None)
+
+        -  applications(application\_ids=None)
+
+        -  window\_titles(window\_title\_ids=None)
+
+        
+
+        Methods return TCItem object (or lists or generators) where the top
+
+        level keys are mapped to object attributes.
+
+        
+
+        Example Usage
+
+        -------------
+
+        
+
+        ::
+
+        
+
+            from pytimecamp import Timecamp
+
+        
+
+            tc = Timecamp("s0met0k3nap1k3ystr1ng")
+
+            for u in tc.users:
+
+                print(u)
+
+                # <User 444444>
+
+                # login_time: 2015-06-01 08:27:14
+
+                # email: nospamthanks@agiletek.co.mk
+
+                # display_name: Steven Rossiter
+
+                # user_id: 444444
+
+                # synch_time: 2015-06-04 15:08:37
+
+                # login_count: 98
+
+        
+
+        
+
+            # Get my entries since 23rd May
+
+            me = list(tc.users)[0] # Timecamp.users is a generator
+
+        
+
+            # You pass dates as strings written like a normal person! (almost any date format 
+
+            # will work - dateutil rocks - but try not confuse it with DDMMYY vs. MMDDYY)
+
+            for entry in tc.entries(from_date="23rd May 2015", user_ids=[me.user_id]):
+
+                print(entry)
+
+                # <Entry 44444444>
+
+                # duration: 1374
+
+                # user_name: Steven Rossiter
+
+                # locked: 0
+
+                # start_time: 10:09:13
+
+                # billable: 0
+
+                # description:
+
+                # name: CRM, Sales & Marketing
+
+                # id: 44444444
+
+                # last_modify: 2015-05-26 11:38:24
+
+                # end_time: 10:32:11
+
+                # user_id: 444444
+
+                # task_id: 4444444
+
+                # invoiceId: 0
+
+                # date: 2015-05-26
+
+        
+
+            # get the task with ID 4444444 with the users embedded
+
+            task = tc.task_by_id(4444444,True)
+
+            print(task)
+
+            # <Task 4444444>
+
+            # tags: CRM, Sales, Marketing, INT002
+
+            # user_access_type: 3
+
+            # archived: 0
+
+            # users: [
+
+            # <User 444445>
+
+            # display_name: Hugh Martindale
+
+            # email: nospamthanks@agiletek.co.mk
+
+            # synch_time: 2015-06-03 21:04:14
+
+            # login_time: 2015-06-02 14:23:02
+
+            # user_id: 49192
+
+            # login_count: 26,
+
+            # <User 444444>
+
+            # display_name: Steven Rossiter
+
+            # email: nospamthanks@agiletek.co.mk
+
+            # synch_time: 2015-06-04 15:13:42
+
+            # login_time: 2015-06-01 08:27:14
+
+            # user_id: 49191
+
+            # login_count: 98,
+
+            # <User 444446>
+
+            # display_name: Truan Willis
+
+            # email: nospamthanks@agiletek.co.mk
+
+            # synch_time: 2015-06-04 15:17:58
+
+            # login_time: 2015-06-03 11:32:22
+
+            # user_id: 444446
+
+            # login_count: 81,
+
+            # <User 444447>
+
+            # display_name: Richard Langdon
+
+            # email: richard@agiletek.co.uk
+
+            # synch_time: 2015-06-04 15:14:36
+
+            # login_time: 2015-06-03 20:01:52
+
+            # user_id: 444447
+
+            # login_count: 103]
+
+            # external_parent_id: None
+
+            # name: CRM, Sales & Marketing
+
+            # billable: 0
+
+            # parent_id: 3333333
+
+            # task_id: 4444444
+
+            # perms: {'5': 3, '6': 3, '7': 3, '1': 3, '3': 3, '2': 3}
+
+            # color: #34C644
+
+            # root_group_id: 27055
+
+            # level: 2
+
+            # budgeted: 0
+
+        
+
+        Licence
+
+        -------
+
+        
+
+        MIT (c) 2015 AgileTek Engineering Limited
+
+        
+
+        Changelog
+
+        ---------
+
+        
+
+        v0.
+
         
 Platform: UNKNOWN
 Classifier: Development Status :: 4 - Beta


### PR DESCRIPTION
Move the changes made in 885e07417b43c0984b689c8812becd3f6a58e2d7 to build/lib/pytimecamp so that we can pip install directly from git correctly.

Have added note to changelog and updated version in PKG-INFO